### PR TITLE
overlay: Remove the default battery style and set it in frameworks

### DIFF
--- a/overlay/common/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/overlay/common/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -19,9 +19,6 @@
 <resources>
     <string name="def_backup_transport">com.google.android.backup/.BackupTransportService</string>
 
-    <!-- Circle -->
-    <integer name="def_battery_style">2</integer>
-
     <!-- Enable notification counters in statusbar -->
     <integer name="def_notif_count">1</integer>
 


### PR DESCRIPTION
This will allow us to remove the overlay in vendor/cm so devices
with no battery, aka fugu, can override this to none.

Change-Id: I80c0cc06d3aed344c7c705d420af297c96baf706